### PR TITLE
ID-n-Name Async Dev

### DIFF
--- a/workflows/wf_basespace_fetch.wdl
+++ b/workflows/wf_basespace_fetch.wdl
@@ -28,7 +28,7 @@ workflow basespace_fetch {
     String basespace_fetch_analysis_date = version_capture.date
     
     File read1 = fetch_bs.read1
-    File read2 = fetch_bs.read2
+    File? read2 = fetch_bs.read2
   }
 }
 task fetch_bs {
@@ -114,7 +114,7 @@ task fetch_bs {
   >>>
   output {
     File read1 = "~{sample_name}_R1.fastq.gz"
-    File read2 = "~{sample_name}_R2.fastq.gz"
+    File? read2 = "~{sample_name}_R2.fastq.gz"
   }
   runtime {
     docker: "theiagen/basespace_cli:1.2.1"

--- a/workflows/wf_basespace_fetch.wdl
+++ b/workflows/wf_basespace_fetch.wdl
@@ -5,8 +5,8 @@ import "../tasks/task_versioning.wdl" as versioning
 workflow basespace_fetch {
   input {
     String sample_name
-    String bs_sample_name
-    String? bs_sample_id
+    String basespace_sample_name
+    String? basespace_sample_id
     String basespace_run_name
     String api_server
     String access_token
@@ -14,8 +14,8 @@ workflow basespace_fetch {
   call fetch_bs {
     input:
       sample_name = sample_name,
-      bs_sample_id = bs_sample_id,
-      bs_sample_name = bs_sample_name,
+      basespace_sample_id = basespace_sample_id,
+      basespace_sample_name = basespace_sample_name,
       basespace_run_name = basespace_run_name,
       api_server = api_server,
       access_token = access_token
@@ -34,8 +34,8 @@ workflow basespace_fetch {
 task fetch_bs {
   input {
     String sample_name
-    String bs_sample_name
-    String? bs_sample_id
+    String basespace_sample_name
+    String? basespace_sample_id
     String basespace_run_name
     String api_server
     String access_token
@@ -46,13 +46,13 @@ task fetch_bs {
   }
   command <<<
     # set basespace name and id variables
-    if [[ ! -z "~{bs_sample_id}" ]]
+    if [[ ! -z "~{basespace_sample_id}" ]]
     then
-      sample_identifier="~{bs_sample_name}"
-      dataset_name="~{bs_sample_id}"
+      sample_identifier="~{basespace_sample_name}"
+      dataset_name="~{basespace_sample_id}"
     else
-      sample_identifier="~{bs_sample_name}"
-      dataset_name="~{bs_sample_name}"
+      sample_identifier="~{basespace_sample_name}"
+      dataset_name="~{basespace_sample_name}"
     fi
     
     # print all relevant input variables to stdout


### PR DESCRIPTION
This PR addresses #13 as it creates the optional `basespace_sample_id` input variable in instances that the BaseSpace sample sheet `sample_name` and `sample_id` values disagree. 

This PR also updates the input variable names to coincide with the BaseSpace sample sheet column headers rather than the `bs cli` variable names:
- `dataset_name` ->  `basespace_sample_name`

The read2 output file has also been made optional to allow for SE data fetching