### PR TITLE
Add column to capture table_id in exported json

### DIFF
--- a/workflows/wf_terra2bq.wdl
+++ b/workflows/wf_terra2bq.wdl
@@ -122,7 +122,7 @@ task terra_to_bigquery {
     writer.writerows(rows)
 
   # Add column to capture source terra table (table_id) 
-  with open('out_fname+'_temp.tsv','r') as csvinput:
+  with open(out_fname+'_temp.tsv','r') as csvinput:
     with open(out_fname+'.tsv', 'w') as csvoutput:
         writer = csv.writer(csvoutput, delimiter='\t')
         reader = csv.reader(csvinput, delimiter='\t')

--- a/workflows/wf_terra2bq.wdl
+++ b/workflows/wf_terra2bq.wdl
@@ -173,8 +173,6 @@ task terra_to_bigquery {
 
       # add date tag when transferring file to gcp
       date_tag=$(date +"%Y-%m-%d-%Hh-%Mm-%Ss")
-      gsutil -m cp ${table_id}_temp.tsv "~{gcs_uri_prefix}tsv_check/"
-      gsutil -m cp ${table_id}.tsv "~{gcs_uri_prefix}tsv_check/"
       gsutil -m cp "${table_id}.json" "~{gcs_uri_prefix}${table_id}_${date_tag}.json"
       echo "${table_id}_${date_tag}.json copied to ~{gcs_uri_prefix} (${date_tag})"
     done

--- a/workflows/wf_terra2bq.wdl
+++ b/workflows/wf_terra2bq.wdl
@@ -130,7 +130,7 @@ task terra_to_bigquery {
         all = []
         tsv_row = next(reader)
         tsv_row.append("source_terra_table")
-        all.append(row)
+        all.append(tsv_row)
 
         for tsv_row in reader:
             tsv_row.append(out_fname)

--- a/workflows/wf_terra2bq.wdl
+++ b/workflows/wf_terra2bq.wdl
@@ -173,8 +173,8 @@ task terra_to_bigquery {
 
       # add date tag when transferring file to gcp
       date_tag=$(date +"%Y-%m-%d-%Hh-%Mm-%Ss")
-      gsutil -m cp ${table_id}_temp.json "~{gcs_uri_prefix}tsv_check/"
-      gsutil -m cp ${table_id}.json "~{gcs_uri_prefix}tsv_check/"
+      gsutil -m cp ${table_id}_temp.tsv "~{gcs_uri_prefix}tsv_check/"
+      gsutil -m cp ${table_id}.tsv "~{gcs_uri_prefix}tsv_check/"
       gsutil -m cp "${table_id}.json" "~{gcs_uri_prefix}${table_id}_${date_tag}.json"
       echo "${table_id}_${date_tag}.json copied to ~{gcs_uri_prefix} (${date_tag})"
     done

--- a/workflows/wf_terra2bq.wdl
+++ b/workflows/wf_terra2bq.wdl
@@ -128,13 +128,13 @@ task terra_to_bigquery {
         reader = csv.reader(csvinput, delimiter='\t')
 
         all = []
-        row = next(reader)
-        row.append("source_terra_table")
+        tsv_row = next(reader)
+        tsv_row.append("source_terra_table")
         all.append(row)
 
-        for row in reader:
-            row.append(out_fname)
-            all.append(row)
+        for tsv_row in reader:
+            tsv_row.append(out_fname)
+            all.append(tsv_row)
 
         writer.writerows(all)
 


### PR DESCRIPTION
This PR adds to the python block to modify the terra data table tsv:
- Createsa new column (source_terra_table) 
- Populates new column with the table_id for every sample
- This modification occurs before converting tsv to json and exporting json to the target gcp bucket

This PR also updates dat_tag within for loop