### PR TITLE
Enable zcat in concatenate_column_content

### DIFF
--- a/tasks/task_file_handling.wdl
+++ b/tasks/task_file_handling.wdl
@@ -107,7 +107,13 @@ task cat_files {
     # cat files one by one and store them in the concatenated_files file
     for index in ${!file_array[@]}; do
       file=${file_array[$index]}
-      cat ${file} >> ~{concatenated_file_name}
+      if [[ "${file}" == *".gz" ]] ; then 
+        cat_reads="zcat"
+      else
+        cat_reads="cat"
+      fi 
+
+      $cat_reads ${file} >> ~{concatenated_file_name}
     done
 >>>
   output {


### PR DESCRIPTION
This PR adds zcat to the concatenate_column_content workflow so gzipped files can be concatenated. You can now have a mixture of gzipped and uncompressed files in your input array as each file is checked for gz compression before concatenation. Added on request of LA County PHL.

