### PR TITLE
Improvements to Terra_2_NCBI

### DIFF
--- a/tasks/task_broad_ncbi_tools.wdl
+++ b/tasks/task_broad_ncbi_tools.wdl
@@ -5,13 +5,13 @@ task ncbi_sftp_upload {
     File submission_xml
     Array[File] additional_files = []
     File config_js
-    Boolean production_submission
+    Boolean submit_to_production
 
     String wait_for="1"  # all, disabled, some number
   }
   command <<<
     # if this is a production submission, then path = production
-    if ~{production_submission}; then
+    if ~{submit_to_production}; then
       path="Production"
     else # this is a test submission
       path="Test"
@@ -93,7 +93,7 @@ task biosample_submit_tsv_ftp_upload {
   input {
     File meta_submit_tsv
     File config_js
-    Boolean production_submission
+    Boolean submit_to_production
   }
   String base=basename(meta_submit_tsv, '.tsv')
   meta {
@@ -101,7 +101,7 @@ task biosample_submit_tsv_ftp_upload {
   }
   command <<<
     # if this is a production submission, then path = production
-     if ~{production_submission}; then
+     if ~{submit_to_production}; then
       path="Production"
     else # this is a test submission
       path="Test"

--- a/tasks/task_broad_ncbi_tools.wdl
+++ b/tasks/task_broad_ncbi_tools.wdl
@@ -5,15 +5,15 @@ task ncbi_sftp_upload {
     File submission_xml
     Array[File] additional_files = []
     File config_js
-    String target_path
+    Boolean production_submission
 
     String wait_for="1"  # all, disabled, some number
   }
   command <<<
-    # append current date to the second to end of target_path 
-    if [ ~"{target_path}" == "production" ] || [ "~{target_path}" == "Production" ]; then
+    # if this is a production submission, then path = production
+    if ~{production_submission}; then
       path="Production"
-    else # if they don't put in production, it will default to Test
+    else # this is a test submission
       path="Test"
     fi
 
@@ -28,7 +28,7 @@ task ncbi_sftp_upload {
       cp ~{sep=' ' additional_files} files/
     fi
     MANIFEST=$(ls -1 files | paste -sd,)
-    echo "uploading: $MANIFEST to destination ftp folder ~{target_path}"
+    echo "uploading: $MANIFEST to destination ftp folder ${path}"
     echo "Asymmetrik script version: $ASYMMETRIK_REPO_COMMIT"
     node src/main.js --debug \
       --uploadFiles="$MANIFEST" \
@@ -93,17 +93,17 @@ task biosample_submit_tsv_ftp_upload {
   input {
     File meta_submit_tsv
     File config_js
-    String target_path
+    Boolean production_submission
   }
   String base=basename(meta_submit_tsv, '.tsv')
   meta {
     description: "This registers a table of metadata with NCBI BioSample. It accepts a TSV similar to the web UI input at submit.ncbi.nlm.nih.gov, but converts to an XML, submits via their FTP/XML API, awaits a response, and retrieves a resulting attributes table and returns that as a TSV. This task registers live data with the production NCBI database."
   }
   command <<<
-    # append current date to the second to end of target_path 
-    if [ ~"{target_path}" == "production" ] || [ "~{target_path}" == "Production" ]; then
+    # if this is a production submission, then path = production
+     if ~{production_submission}; then
       path="Production"
-    else # if they don't put in production, it will default to Test
+    else # this is a test submission
       path="Test"
     fi
 

--- a/tasks/task_submission.wdl
+++ b/tasks/task_submission.wdl
@@ -33,7 +33,7 @@ task prune_table {
 
     # read export table into pandas
     tablename = "~{table_name}-data.tsv"
-    table = pd.read_csv(tablename, delimiter='\t', header=0)
+    table = pd.read_csv(tablename, delimiter='\t', header=0, dtype={"~{table_name}_id": 'str'}) # ensure sample_id is always a string)
 
     # extract the samples for upload from the entire table
     table = table[table["~{table_name}_id"].isin("~{sep='*' sample_names}".split("*"))]

--- a/tasks/task_submission.wdl
+++ b/tasks/task_submission.wdl
@@ -111,7 +111,7 @@ task prune_table {
     # remove required rows with blank cells from table
     table, excluded_samples = remove_nas(table, required_fields)
     with open("excluded_samples.tsv", "a") as exclusions:
-      exclusions.write("\nSamples excluded for missing required metadata (will have empty values in indicated columns):\n")
+      exclusions.write("Samples excluded for missing required metadata (will have empty values in indicated columns):\n")
     excluded_samples.to_csv("excluded_samples.tsv", mode='a', sep='\t')
 
     # add bioproject_accesion to table

--- a/tasks/task_submission.wdl
+++ b/tasks/task_submission.wdl
@@ -11,6 +11,8 @@ task prune_table {
     String bioproject
     String gcp_bucket_uri
     Boolean skip_biosample
+    String read1_column_name = "read1"
+    String read2_column_name = "read2"
   }
   command <<<
     # when running on terra, comment out all input_table mentions
@@ -30,6 +32,17 @@ task prune_table {
     import pandas as pd
     import numpy as np
     import os
+
+    # set a function to remove NA values and return the cleaned table and a table of excluded samples
+    def remove_nas(table, required_metadata):
+      table.replace(r'^\s+$', np.nan, regex=True) # replace blank cells with NaNs 
+      excluded_samples = table[table[required_metadata].isna().any(axis=1)] # write out all rows that are required with NaNs to a new table
+      excluded_samples.set_index("~{table_name}_id".lower(), inplace=True) # convert the sample names to the index so we can determine what samples are missing what
+      excluded_samples = excluded_samples[excluded_samples.columns.intersection(required_metadata)] # remove all optional columns so only required columns are shown
+      excluded_samples = excluded_samples.loc[:, excluded_samples.isna().any()] # remove all NON-NA columns so only columns with NAs remain; Shelly is a wizard and I love her 
+      table.dropna(subset=required_metadata, axis=0, how='any', inplace=True) # remove all rows that are required with NaNs from table
+
+      return table, excluded_samples
 
     # read export table into pandas
     tablename = "~{table_name}-data.tsv"
@@ -85,21 +98,22 @@ task prune_table {
       raise Exception('Only "Microbe", "Virus", "Pathogen" and "Wastewater" are supported as acceptable input for the \`biosample_type\` variable at this time. You entered ~{biosample_type}.')
 
     # sra metadata is the same regardless of biosample_type package, but I'm separating it out in case we find out this is incorrect
-    sra_fields = ["~{table_name}_id", "submission_id", "library_ID", "title", "library_strategy", "library_source", "library_selection", "library_layout", "platform", "instrument_model", "design_description", "filetype", "read1", "read2"] # make some of these optional; for when there is single-end data
-    
-    # if biosample accessions are provided, add those to the end of the sra_metadata field
+    sra_required = ["~{table_name}_id", "submission_id", "library_ID", "title", "library_strategy", "library_source", "library_selection", "library_layout", "platform", "instrument_model", "design_description", "filetype", "~{read1_column_name}"]
+    sra_optional = ["~{read2_column_name}"]
+
+    # if biosample accessions are provided, add those to the end of the sra_required field
     if (os.environ["skip_bio"] == "true"):
-      sra_fields.append("biosample_accession")
+      sra_required.append("biosample_accession")
 
     # combine all required fields into one array for easy removal of NaN cells
-    required_fields = required_metadata + sra_fields
+    required_fields = required_metadata + sra_required
 
     # remove required rows with blank cells from table
-    table.replace(r'^\s+$', np.nan, regex=True) # replace blank cells with NaNs 
-    excluded_samples = table[table[required_fields].isna().any(axis=1)] # write out all rows that are required with NaNs to a new table
-    excluded_samples["~{table_name}_id"].to_csv("excluded_samples.tsv", sep='\t', index=False, header=False) # write the excluded names out to a file
-    table.dropna(subset=required_fields, axis=0, how='any', inplace=True) # remove all rows that are required with NaNs from table
-    
+    table, excluded_samples = remove_nas(table, required_fields)
+    with open("excluded_samples.tsv", "a") as exclusions:
+      exclusions.write("\nSamples excluded for missing required metadata (will have empty values in indicated columns):\n")
+    excluded_samples.to_csv("excluded_samples.tsv", mode='a', sep='\t')
+
     # add bioproject_accesion to table
     table["bioproject_accession"] = "~{bioproject}"
     
@@ -113,18 +127,21 @@ task prune_table {
     biosample_metadata.rename(columns={"submission_id" : "sample_name"}, inplace=True)
 
     # extract the required metadata from the table; rename first column 
-    sra_metadata = table[sra_fields].copy()
+    sra_metadata = table[sra_required].copy()
+    for column in sra_optional:
+      if column in table.columns:
+        sra_metadata[column] = table[column]
     sra_metadata.rename(columns={"submission_id" : "sample_name"}, inplace=True)
 
     # prettify the filenames and rename them to be sra compatible
-    sra_metadata["read1"] = sra_metadata["read1"].map(lambda filename: filename.split('/').pop())
-    sra_metadata["read2"] = sra_metadata["read2"].map(lambda filename2: filename2.split('/').pop())   
-    sra_metadata.rename(columns={"read1" : "filename", "read2" : "filename2"}, inplace=True)
- 
-    ### Create a file that contains the names of all the reads so we can use gsutil -m cp
-    table["read1"].to_csv("filepaths.tsv", index=False, header=False)
-    table["read2"].to_csv("filepaths.tsv", mode='a', index=False, header=False)
-
+    sra_metadata["~{read1_column_name}"] = sra_metadata["~{read1_column_name}"].map(lambda filename: filename.split('/').pop())
+    sra_metadata.rename(columns={"~{read1_column_name}" : "filename"}, inplace=True)
+    table["~{read1_column_name}"].to_csv("filepaths.tsv", index=False, header=False) # make a file that contains the names of all the reads so we can use gsutil -m cp
+    if "~{read2_column_name}" in sra_metadata.columns:
+      sra_metadata["~{read2_column_name}"] = sra_metadata["~{read2_column_name}"].map(lambda filename2: filename2.split('/').pop())   
+      sra_metadata.rename(columns={"~{read2_column_name}" : "filename2"}, inplace=True)
+      table["~{read2_column_name}"].to_csv("filepaths.tsv", mode='a', index=False, header=False)
+    
     # write metadata tables to tsv output files
     biosample_metadata.to_csv("biosample_table.tsv", sep='\t', index=False)
     sra_metadata.to_csv("sra_table_to_edit.tsv", sep='\t', index=False)

--- a/workflows/wf_terra_2_ncbi.wdl
+++ b/workflows/wf_terra_2_ncbi.wdl
@@ -14,7 +14,7 @@ workflow Terra_2_NCBI {
     File ncbi_config_js
     File? input_table # for command line testing only
     String biosample_package # used to be biosample_type
-    String gcp_bucket_uri
+    String sra_transfer_gcp_bucket # used to be gcp_bucket_uri
     Boolean submit_to_production = false # used to be path_on_ftp_server
     String bioproject
   }
@@ -30,7 +30,7 @@ workflow Terra_2_NCBI {
       input_table = input_table,
       biosample_type = biosample_package,
       bioproject = bioproject,
-      gcp_bucket_uri = gcp_bucket_uri,
+      gcp_bucket_uri = sra_transfer_gcp_bucket,
       skip_biosample = skip_biosample
   }
   if (skip_biosample == false){
@@ -55,7 +55,7 @@ workflow Terra_2_NCBI {
         meta_submit_tsv = select_first([add_biosample_accessions.sra_table, prune_table.sra_table]),
         config_js = ncbi_config_js,
         bioproject = bioproject,
-        data_bucket_uri = gcp_bucket_uri
+        data_bucket_uri = sra_transfer_gcp_bucket
     }
     call ncbi_tools.ncbi_sftp_upload {
       input: 

--- a/workflows/wf_terra_2_ncbi.wdl
+++ b/workflows/wf_terra_2_ncbi.wdl
@@ -15,7 +15,7 @@ workflow Terra_2_NCBI {
     File? input_table # for command line testing only
     String biosample_package # used to be biosample_type
     String gcp_bucket_uri
-    Boolean production_submission = false # used to be path_on_ftp_server
+    Boolean submit_to_production = false # used to be path_on_ftp_server
     String bioproject
   }
   call versioning.version_capture{
@@ -38,7 +38,7 @@ workflow Terra_2_NCBI {
       input:
         meta_submit_tsv = prune_table.biosample_table, 
         config_js = ncbi_config_js, 
-        production_submission = production_submission
+        submit_to_production = submit_to_production
     }
     call submission.add_biosample_accessions {
       input:
@@ -61,7 +61,7 @@ workflow Terra_2_NCBI {
       input: 
         submission_xml = sra_tsv_to_xml.submission_xml,
         config_js = ncbi_config_js,
-        production_submission = production_submission
+        submit_to_production = submit_to_production
     }
   }
   output {

--- a/workflows/wf_terra_2_ncbi.wdl
+++ b/workflows/wf_terra_2_ncbi.wdl
@@ -12,10 +12,10 @@ workflow Terra_2_NCBI {
     Array[String] sample_names
     Boolean skip_biosample = false 
     File ncbi_config_js
-    File? input_table
-    String biosample_type
+    File? input_table # for command line testing only
+    String biosample_package # used to be biosample_type
     String gcp_bucket_uri
-    String path_on_ftp_server
+    Boolean production_submission = false # used to be path_on_ftp_server
     String bioproject
   }
   call versioning.version_capture{
@@ -28,7 +28,7 @@ workflow Terra_2_NCBI {
       table_name = table_name,
       sample_names = sample_names,
       input_table = input_table,
-      biosample_type = biosample_type,
+      biosample_type = biosample_package,
       bioproject = bioproject,
       gcp_bucket_uri = gcp_bucket_uri,
       skip_biosample = skip_biosample
@@ -38,7 +38,7 @@ workflow Terra_2_NCBI {
       input:
         meta_submit_tsv = prune_table.biosample_table, 
         config_js = ncbi_config_js, 
-        target_path = path_on_ftp_server
+        production_submission = production_submission
     }
     call submission.add_biosample_accessions {
       input:
@@ -61,7 +61,7 @@ workflow Terra_2_NCBI {
       input: 
         submission_xml = sra_tsv_to_xml.submission_xml,
         config_js = ncbi_config_js,
-        target_path = path_on_ftp_server
+        production_submission = production_submission
     }
   }
   output {


### PR DESCRIPTION
This PR improves Terra_2_NCBI by closing #28:

- it adds SE support
- it enables using different read1/read2 files using new optional variables `read1_column_name` and `read2_column_name`
- it now supplies the reason why some samples are excluded by indicating what required columns have missing data
- it renames some input variables to be more clear and intuitive; for example:
  - `biosample_type` is now `biosample_package`
  - **MAJOR CHANGE:** `path_on_ftp_server` **is now a Boolean variable** called `submit_to_production` where it is by default `false`, meaning a Test submission will be performed. If set to `true` then a Production submission will occur.
  - `gcp_bucket_uri` is now `sra_transfer_gcp_bucket`
- a bug fix was implemented that prevents failure in the rare case where sample_ids are made of only numbers
  